### PR TITLE
＃6　登録後のリダイレクトとフラッシュメッセージの設定

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
 
 class LoginController extends Controller
 {
@@ -36,5 +37,25 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+    
+    // AuthenticatesUsersトレイトのauthenticatedメソッドをオーバーライド
+    protected function authenticated(Request $request, $user)
+    {
+        // ログイン成功時、トップ画面へ遷移し、フラッシュメッセージを表示
+        return redirect()->route('top')->with('success', 'ログインに成功しました。');
+    }
+
+    // AuthenticatesUsersトレイトのlogoutメソッドをオーバーライド
+    public function logout(Request $request)
+    {
+        $this->guard()->logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        // ログアウト成功時、トップ画面へ遷移し、フラッシュメッセージを表示
+        return redirect()->route('top')->with('success', 'ログアウトしました。');
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,7 +8,7 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
-
+use Illuminate\Http\Request;
 class RegisterController extends Controller
 {
     /*
@@ -70,4 +70,11 @@ class RegisterController extends Controller
             'password' => Hash::make($data['password']),
         ]);
     }
+    
+    // RegistersUsersトレイトのregisteredメソッドをオーバーライド
+    protected function registered(Request $request, $user)
+    {
+        // ユーザ新規登録成功時、トップ画面へ遷移し、フラッシュメッセージを表示
+        return redirect()->route('top')->with('success', 'ユーザ新規登録に成功しました');
+    }    
 }

--- a/resources/views/commons/success_messages.blade.php
+++ b/resources/views/commons/success_messages.blade.php
@@ -1,0 +1,5 @@
+@if (session('success'))
+    <ul class="alert alert-success" role="success">
+        <li class="ml-4">{{ session('success') }}</li>
+    </ul>
+@endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,6 @@
 @extends('layouts.app')
 @section('content')
+@include('commons.success_messages')
     <div class="center jumbotron app-bg-color">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="fas fa-envelope pr-3 d-inline icon-large"></i>Ray mail system</h1>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,4 +19,4 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
-Route::get('/', 'UsersController@index');
+Route::get('/', 'UsersController@index')->name('top');


### PR DESCRIPTION
## issue
- closes  #6 
## 概要
- ### このタスクにおける目標

1. 会員登録後、ログアウト後、ログイン後のフラッシュメッセージの設定
![スクリーンショット 2024-12-10 190319 - コピー](https://github.com/user-attachments/assets/3092c8ad-57ed-45f8-89ea-e04ec1c1781a)

### 1. Router

まずルーティングから記述
`routes/web.php`
ルーティングに命名
`Route::get('/', 'UsersController@index')->name('top');`

### 2. Controller
`app/Http/Controllers/Auth/LoginController.php`
`app/Http/Controllers/Auth/RegisterController.php`
フラッシュメッセージの内容を実装

### 3. View
`resources/views/commons/success_messages.blade.php`
LaravelのBladeテンプレートでセッションに保存された「成功メッセージ」を表示するためのもの。

> - 実行結果の流れ
> 
> サーバー側でセッションに success キーとメッセージを保存。
> ユーザーがリダイレクト先のページを開く。
> Bladeテンプレートで session('success') をチェック。
> success メッセージが存在すれば、HTML内にメッセージが表示される。

### 4. `welcome.blade.php`にインクルードさせてトップページに表示させる
`resources/views/welcome.blade.php`
Bladeテンプレートの@includeディレクティブは、別のBladeファイルを読み込んで、現在のテンプレートに埋め込むためのもの。

完成ピクチャー
![スクリーンショット 2024-12-10 225735](https://github.com/user-attachments/assets/aa495b41-fe13-4d3d-91ed-85ae90a13348)
![スクリーンショット 2024-12-10 225755](https://github.com/user-attachments/assets/8aca4ca6-f2fa-420e-95aa-f8681f032926)
![スクリーンショット 2024-12-10 225829](https://github.com/user-attachments/assets/5ad6b1a2-8025-4218-a177-872c8a547490)

