### PR TITLE
＃12　メールリストモデルとマイグレーションの作成

### DIFF
--- a/app/MailList.php
+++ b/app/MailList.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MailList extends Model
+{
+    //
+}

--- a/database/migrations/2024_12_12_050642_create_mail_lists_table.php
+++ b/database/migrations/2024_12_12_050642_create_mail_lists_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMailListsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mail_lists', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name'); // メールリストの名前
+            $table->string('email')->unique(); // メールアドレス（ユニーク制約）
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mail_lists');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(MailListSeeder::class);
     }
 }

--- a/database/seeds/MailListSeeder.php
+++ b/database/seeds/MailListSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\MailList;
+
+class MailListSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            MailList::create([
+                'name' => 'Test User ' . $i,
+                'email' => 'testuser' . $i . '@test.com',
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## issue
- closes  #12
## 概要
- ### このタスクにおける目標

1. メールリストモデルとマイグレーションの作成
2. テストユーザー20名の登録実装

### 1. シーダーファイルの作成:
`php artisan make:seeder MailListSeeder`

### 2. シーダーファイルの編集:
`database/seeds/MailListSeeder.php`
シンプルなfor文を使って20名のテストユーザーを登録
メールアドレスが`UsersTableSeeder`で登録済みのテストユーザーと被る為、後半部分を
'@test.com'で登録

### 3. DatabaseSeederファイルの編集: 
`DatabaseSeeder.php`を開き、`MailListSeeder`を呼び出すように編集。


### 4. シーディングの実行: 
以下のコマンドを実行して、20名のテストユーザーをデータベースに登録
`php artisan db:seed
`

完成ピクチャー
![スクリーンショット 2024-12-12 053432](https://github.com/user-attachments/assets/e3e42b0a-262c-440c-a8f1-945b7a933e52)
