### PR TITLE
#23メールテンプレートの一覧表示

### DIFF
--- a/app/Http/Controllers/MailListController.php
+++ b/app/Http/Controllers/MailListController.php
@@ -4,8 +4,7 @@ namespace App\Http\Controllers;
 
 use App\MailList;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator; // Validator をインポート
-
+use Illuminate\Support\Facades\Validator;
 class MailListController extends Controller
 {
     /**

--- a/app/Http/Controllers/MailTemplateController.php
+++ b/app/Http/Controllers/MailTemplateController.php
@@ -31,4 +31,14 @@ class MailTemplateController extends Controller
         // リダイレクトと成功メッセージ
         return redirect()->route('mail-template.create')->with('success', 'メールテンプレートが作成されました！');
     }
+    
+    public function index()
+    {
+        // メールテンプレートを取得
+        $mailTemplates = MailTemplate::all();
+
+        // ビューにデータを渡す
+        return view('mail-template.index', compact('mailTemplates'));
+    }
+
 }

--- a/resources/views/mail-template/index.blade.php
+++ b/resources/views/mail-template/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>メールテンプレート一覧</h1>
+
+    <!-- テンプレート一覧 -->
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>テンプレート名</th>
+                <th>件名</th>
+                <th>作成日</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($mailTemplates as $template)
+                <tr>
+                    <td>{{ $template->id }}</td>
+                    <td>{{ $template->name }}</td>
+                    <td>{{ $template->subject }}</td>
+                    <td>{{ $template->created_at->format('Y-m-d') }}</td>
+                    <td>
+                        <!-- 操作ボタン -->
+                        <a href="#" class="btn btn-info btn-sm">詳細</a>
+                        <a href="#" class="btn btn-primary btn-sm">編集</a>
+                        <form action="#" method="POST" style="display:inline;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger btn-sm">削除</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <!-- 新規作成ボタン -->
+    <a href="{{ route('mail-template.create') }}" class="btn btn-success">新規作成</a>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::group(['middleware' => 'auth'], function () {
     });
     // メールテンプレート作成フォームと保存処理
     Route::prefix('mail-template')->group(function () {
+        Route::get('/', 'MailTemplateController@index')->name('mail-template.index'); // 一覧表示
         Route::get('create', 'MailTemplateController@create')->name('mail-template.create'); // フォーム表示
         Route::post('store', 'MailTemplateController@store')->name('mail-template.store');   // フォーム送信処理
     });


### PR DESCRIPTION
## issue
- closes  #23
## 概要
- ### このタスクにおける目標
メールテンプレートをデータベースから取得し、一覧ページに表示する機能を作成。

## 目標ピクチャー
![スクリーンショット 2024-12-16 192604](https://github.com/user-attachments/assets/c9ad340c-5b40-48b5-a1e3-3a1aba00055a)
![スクリーンショット 2024-12-18 204557](https://github.com/user-attachments/assets/8d17d82e-4749-44ab-80b3-719c7ea5a659)


### 1. ルーティング（routes/web.php）
ルーティングの追加

```
// メールテンプレート一覧表示
Route::prefix('mail-template')->group(function () { 
　Route::get('/', 'MailTemplateController@index')->name('mail-template.index'); // 一覧表示 
　Route::get('create', 'MailTemplateController@create')->name('mail-template.create'); // 作成フォーム 
　Route::post('store', 'MailTemplateController@store')->name('mail-template.store'); // 作成保存 
});

```

### 2. コントローラの実装
`MailTemplateController` に一覧表示用のメソッドを追加。
ファイル: `app/Http/Controllers/MailTemplateController.php`


### 3. ビューの作成
メールテンプレートの一覧を表示するビューを新規作成。
ファイル: `resources/views/mail-template/index.blade.php`


### 4. 動作確認

- ブラウザで確認
http://localhost:8080/mail-template にアクセス。
- 登録されたテンプレートの一覧が表示されていることを確認。
- 一覧ページが表示され、登録されたテンプレートのデータがテーブル形式で表示されていることを確認します。

### 5. まとめ
作成ファイルと修正箇所

- ルート: `routes/web.php`一覧表示のルートを追加
- コントローラ: `MailTemplateController@index` メソッド追加
- ビュー: `resources/views/mail-template/index.blade.php`

一覧表示の特徴

- メールテンプレートをテーブル形式で表示。
- 詳細、編集、削除ボタンを設置し、後続の機能に備える。
- 新規作成ボタンでテンプレート作成画面に遷移可能。


## 完成ピクチャー
![スクリーンショット 2024-12-18 205442](https://github.com/user-attachments/assets/708ff11c-6a38-4bd4-b3c1-38731f411682)

