### PR TITLE
#25メールテンプレートの削除機能の実装

### DIFF
--- a/app/Http/Controllers/MailTemplateController.php
+++ b/app/Http/Controllers/MailTemplateController.php
@@ -66,4 +66,14 @@ class MailTemplateController extends Controller
         // リダイレクトと成功メッセージ
         return redirect()->route('mail-template.index')->with('success', 'メールテンプレートが更新されました！');
     }
+
+    public function destroy($id)
+    {
+        // メールテンプレートを検索して削除
+        $mailTemplate = MailTemplate::findOrFail($id);
+        $mailTemplate->delete();
+
+        // リダイレクトと成功メッセージ
+        return redirect()->route('mail-template.index')->with('success', 'メールテンプレートが削除されました！');
+    }
 }

--- a/resources/views/mail-template/index.blade.php
+++ b/resources/views/mail-template/index.blade.php
@@ -26,7 +26,7 @@
                         <!-- 操作ボタン -->
                         <a href="#" class="btn btn-info btn-sm">詳細</a>
                         <a href="{{ route('mail-template.edit', $template->id) }}" class="btn btn-primary btn-sm">編集</a>
-                        <form action="#" method="POST" style="display:inline;">
+                        <form action="{{ route('mail-template.destroy', $template->id) }}" method="POST" style="display:inline;" onsubmit="return confirm('本当に削除しますか？');">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger btn-sm">削除</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,5 +41,6 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('store', 'MailTemplateController@store')->name('mail-template.store');   // 作成保存
         Route::get('edit/{id}', 'MailTemplateController@edit')->name('mail-template.edit');  // 編集フォーム
         Route::post('update/{id}', 'MailTemplateController@update')->name('mail-template.update'); // 更新処理
+        Route::delete('mail-template/{id}', 'MailTemplateController@destroy')->name('mail-template.destroy'); // 削除処理
     });
 });


### PR DESCRIPTION
## issue
- closes  #25 
## 概要
- ### このタスクにおける目標
メールテンプレートを不要になった場合や間違えて作成した場合に削除できる機能を実装することが目的。
これにより、テンプレート管理が効率化され、システム内でのデータの整理が容易になる。


## 目標ピクチャー
![スクリーンショット 2024-12-19 182336](https://github.com/user-attachments/assets/b3ebf48b-b981-4aa3-aa34-56872d6c8420)



### 1. ルーティング（routes/web.php）
削除機能のエンドポイントを追加します。
目的: メールテンプレートを削除するためのHTTPリクエストを受け取る。
手順: routes/web.php に削除用のルートを追加。

// メールテンプレートの削除
`Route::delete('mail-template/{id}', 'MailTemplateController@destroy')->name('mail-template.destroy');`

### 2. コントローラの実装
`MailTemplateController` に一覧表示用のメソッドを追加。
ファイル: `app/Http/Controllers/MailTemplateController.php`


### 3. ビューに削除ボタンを追加
目的: メールテンプレート一覧画面に削除ボタンを設置。
手順: `resources/views/mail-template/index.blade.php `に削除ボタンを追加。

    <form action="{{ route('mail-template.destroy', $mailTemplate->id) }}" method="POST" onsubmit="return confirm('本当に削除しますか？');">


### 4.フロントエンド確認
目的: 削除ボタンが正しく動作するか確認。
手順:
ブラウザでテンプレート一覧画面に移動。
削除ボタンをクリックし、削除後にリダイレクトとメッセージが表示されることを確認。
確認ポイント

- 削除ボタンをクリックすると、ブラウザで確認ダイアログが表示。
- 確認後に削除が正常に行われ、一覧画面にリダイレクト。
- 削除が成功した場合、一覧画面に「削除成功」のメッセージが表示。

### 5. テスト
目的: 削除機能が意図した通り動作するか確認する。
手順:
Laravel Tinker:

// テストデータを追加
\App\MailTemplate::create(['name' => 'Test', 'subject' => 'Test Subject', 'body' => 'Test Body']);
// 削除メソッドを実行
$template = \App\MailTemplate::find(1);
$template->delete();
// 結果確認
\App\MailTemplate::find(1); // null が返ることを確認



## 完成ピクチャー
![スクリーンショット 2024-12-19 191120](https://github.com/user-attachments/assets/ae4a9d4b-6d5f-4671-8c0b-0e096192be86)

