### PR TITLE
#53メールテンプレートの詳細機能の実装

### DIFF
--- a/app/Http/Controllers/MailTemplateController.php
+++ b/app/Http/Controllers/MailTemplateController.php
@@ -76,4 +76,13 @@ class MailTemplateController extends Controller
         // リダイレクトと成功メッセージ
         return redirect()->route('mail-template.index')->with('success', 'メールテンプレートが削除されました！');
     }
+
+    public function show($id)
+    {
+        // 指定されたIDのメールテンプレートを取得
+        $mailTemplate = MailTemplate::findOrFail($id);
+
+        // 詳細表示のビューにデータを渡す
+        return view('mail-template.show', compact('mailTemplate'));
+    }
 }

--- a/resources/views/mail-template/index.blade.php
+++ b/resources/views/mail-template/index.blade.php
@@ -24,7 +24,7 @@
                     <td>{{ $template->created_at->format('Y-m-d') }}</td>
                     <td>
                         <!-- 操作ボタン -->
-                        <a href="#" class="btn btn-info btn-sm">詳細</a>
+                        <a href="{{ route('mail-template.show', $template->id) }}" class="btn btn-info btn-sm">詳細</a>
                         <a href="{{ route('mail-template.edit', $template->id) }}" class="btn btn-primary btn-sm">編集</a>
                         <form action="{{ route('mail-template.destroy', $template->id) }}" method="POST" style="display:inline;" onsubmit="return confirm('本当に削除しますか？');">
                             @csrf

--- a/resources/views/mail-template/show.blade.php
+++ b/resources/views/mail-template/show.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>テンプレート詳細</h1>
+
+    <table class="table table-bordered">
+        <tr>
+            <th>ID</th>
+            <td>{{ $mailTemplate->id }}</td>
+        </tr>
+        <tr>
+            <th>テンプレート名</th>
+            <td>{{ $mailTemplate->name }}</td>
+        </tr>
+        <tr>
+            <th>件名</th>
+            <td>{{ $mailTemplate->subject }}</td>
+        </tr>
+        <tr>
+            <th>本文</th>
+            <td>{{ nl2br(e($mailTemplate->body)) }}</td>
+        </tr>
+        <tr>
+            <th>作成日</th>
+            <td>{{ $mailTemplate->created_at->format('Y-m-d H:i:s') }}</td>
+        </tr>
+        <tr>
+            <th>更新日</th>
+            <td>{{ $mailTemplate->updated_at->format('Y-m-d H:i:s') }}</td>
+        </tr>
+    </table>
+
+    <a href="{{ route('mail-template.index') }}" class="btn btn-secondary">戻る</a>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,5 +42,6 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('edit/{id}', 'MailTemplateController@edit')->name('mail-template.edit');  // 編集フォーム
         Route::post('update/{id}', 'MailTemplateController@update')->name('mail-template.update'); // 更新処理
         Route::delete('mail-template/{id}', 'MailTemplateController@destroy')->name('mail-template.destroy'); // 削除処理
+        Route::get('{id}', 'MailTemplateController@show')->name('mail-template.show'); // 詳細表示
     });
 });


### PR DESCRIPTION
## issue
- closes  #53
## 概要
- ### このタスクにおける目標

- メールテンプレートの詳細機能を実装。
- 一覧画面でテンプレート名や件名だけではわからない詳細な情報（本文など）を表示するページを作成。
- ユーザーが各テンプレートの内容を確認できるようにする。

## 目標ピクチャー
![スクリーンショット 2024-12-19 193251](https://github.com/user-attachments/assets/8e1db345-607e-4233-b49d-af84faddd289)



### 1. ルーティング（routes/web.php）
ルーティングの追加
`Route::get('{id}', 'MailTemplateController@show')->name('mail-template.show');  // 詳細表示`

### 2. コントローラの実装
`MailTemplateController `に詳細機能を追加。
`app/Http/Controllers/MailTemplateController.php`

```
public function show($id)
{
    // 指定されたIDのメールテンプレートを取得
    $mailTemplate = MailTemplate::findOrFail($id);

    // 詳細表示のビューにデータを渡す
    return view('mail-template.show', compact('mailTemplate'));
}
```

### 3. ビューの新規作成
テンプレート詳細を表示するためのビューを新規作成します。
ファイル: `resources/views/mail-template/show.blade.php`


### 4. 一覧ページに「詳細」ボタンのリンクを追加
詳細ページへのリンクを追加します。
修正: `resources/views/mail-template/index.blade.php`

```
<td>
    <!-- 操作ボタン -->
    <a href="{{ route('mail-template.show', $template->id) }}" class="btn btn-info btn-sm">詳細</a>
```

### 5. 動作確認

- 一覧画面
「詳細」ボタンをクリックすると詳細ページに遷移する。
- 詳細ページ
指定されたテンプレートの詳細情報が正しく表示される。
- 「戻る」ボタンを押すと一覧ページに戻る。


## 完成ピクチャー
![スクリーンショット 2024-12-19 193605](https://github.com/user-attachments/assets/9e2f99c2-f5b8-435f-9a57-12c8fa2487e7)

